### PR TITLE
fix: correct multiple bugs in ObservabilityPipelineBehavior and related metrics classes

### DIFF
--- a/src/BuildingBlocks/OpenTelemetryCollector/CoreDiagnostics/Commands/CommandHandlerMetrics.cs
+++ b/src/BuildingBlocks/OpenTelemetryCollector/CoreDiagnostics/Commands/CommandHandlerMetrics.cs
@@ -37,7 +37,7 @@ public class CommandHandlerMetrics
         );
 
         _failedCommandsNumber = diagnosticsProvider.Meter.CreateCounter<long>(
-            TelemetryTags.Metrics.Application.Commands.FaildCount,
+            TelemetryTags.Metrics.Application.Commands.FailedCount,
             unit: "{failed_commands}",
             description: "Number commands that handled with errors"
         );
@@ -113,12 +113,10 @@ public class CommandHandlerMetrics
             _activeCommandsCounter.Add(-1, tags);
         }
 
-        if (!_handlerDuration.Enabled)
-            return;
-
-        var elapsedTimeSeconds = _timer.Elapsed.Seconds;
-
-        _handlerDuration.Record(elapsedTimeSeconds, tags);
+        if (_handlerDuration.Enabled)
+        {
+            _handlerDuration.Record(_timer.Elapsed.TotalSeconds, tags);
+        }
 
         if (_successCommandsNumber.Enabled)
         {
@@ -148,6 +146,16 @@ public class CommandHandlerMetrics
             { TelemetryTags.Tracing.Application.Commands.CommandHandler, commandHandlerName },
             { TelemetryTags.Tracing.Application.Commands.CommandHandlerType, handlerType?.FullName },
         };
+
+        if (_activeCommandsCounter.Enabled)
+        {
+            _activeCommandsCounter.Add(-1, tags);
+        }
+
+        if (_handlerDuration.Enabled)
+        {
+            _handlerDuration.Record(_timer.Elapsed.TotalSeconds, tags);
+        }
 
         if (_failedCommandsNumber.Enabled)
         {

--- a/src/BuildingBlocks/OpenTelemetryCollector/TelemetryTags.cs
+++ b/src/BuildingBlocks/OpenTelemetryCollector/TelemetryTags.cs
@@ -231,7 +231,7 @@ public static class TelemetryTags
                 public static string CommandType = $"{Command}.type";
                 public static string CommandHandler = $"{Command}.handler";
                 public static string SuccessCount = $"{CommandHandler}.success.count";
-                public static string FaildCount = $"{CommandHandler}.failed.count";
+                public static string FailedCount = $"{CommandHandler}.failed.count";
                 public static string ActiveCount = $"{CommandHandler}.active.count";
                 public static string TotalExecutedCount = $"{CommandHandler}.total.count";
                 public static string HandlerDuration = $"{CommandHandler}.duration";
@@ -243,7 +243,7 @@ public static class TelemetryTags
                 public static string QueryType = $"{Query}.type";
                 public static string QueryHandler = $"{Query}.handler";
                 public static string SuccessCount = $"{QueryHandler}.success.count";
-                public static string FaildCount = $"{QueryHandler}.failed.count";
+                public static string FailedCount = $"{QueryHandler}.failed.count";
                 public static string ActiveCount = $"{QueryHandler}.active.count";
                 public static string TotalExecutedCount = $"{QueryHandler}.total.count";
                 public static string HandlerDuration = $"{QueryHandler}.duration";
@@ -255,7 +255,7 @@ public static class TelemetryTags
                 public static string EventType = $"{Event}.type";
                 public static string EventHandler = $"{Event}.handler";
                 public static string SuccessCount = $"{EventHandler}.success.count";
-                public static string FaildCount = $"{EventHandler}.failed.count";
+                public static string FailedCount = $"{EventHandler}.failed.count";
                 public static string ActiveCount = $"{EventHandler}.active.count";
                 public static string TotalExecutedCount = $"{EventHandler}.total.count";
                 public static string HandlerDuration = $"{EventHandler}.duration";


### PR DESCRIPTION
## Summary

- Fix swapped `isCommand`/`isQuery` variable assignments that caused all observability data to be inverted
- Fix `QueryHandlerMetrics` using `Commands` telemetry tags instead of `Queries` tags, causing metric name collisions
- Fix duration measurement using `.Seconds` (0-59 range) instead of `.TotalSeconds`
- Fix active counter not being decremented on exception path in both `CommandHandlerMetrics` and `QueryHandlerMetrics`
- Fix duration not being recorded on exception path
- Fix `FaildCount` typo to `FailedCount` in `TelemetryTags` (Commands, Queries, Events)
- Rename `FailedCommand` to `FailedQuery` in `QueryHandlerMetrics` for naming consistency
- Simplify lambda expressions in pipeline behavior

Closes #33

## Test plan

- [ ] Verify build succeeds with no new errors
- [ ] Send a command and confirm command metrics/tracing are recorded (not query)
- [ ] Send a query and confirm query metrics/tracing are recorded (not command)
- [ ] Trigger an exception and verify active counter decrements back to 0
- [ ] Trigger an exception and verify duration is recorded in histogram
- [ ] Verify query metrics use distinct metric names from command metrics in dashboard
- [ ] Verify operations longer than 60s report correct total seconds